### PR TITLE
feat: getUserTier editUserFavorite 구현

### DIFF
--- a/src/domains/users/users-error.messages.ts
+++ b/src/domains/users/users-error.messages.ts
@@ -18,3 +18,5 @@ export const NOT_ALLOWED_USER = '접근 권한이 없는 유저입니다.';
 
 export const INVALID_CHANGE_NICKNAME =
   '닉네임은 30일에 한번씩 바꿀 수 있습니다';
+
+export const NOT_FOUND_SPORT_TYPE = '존재하지 않는 스포츠타입입니다';

--- a/src/domains/users/users.controller.ts
+++ b/src/domains/users/users.controller.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   Controller,
   ForbiddenException,
+  Get,
   NotFoundException,
   Param,
   Post,
@@ -21,6 +22,7 @@ import {
 } from './users-error.messages';
 import {
   CreateProfileDto,
+  EditFavoriteDto,
   EditProfileDto,
   SignInUserDto,
   SignUpUserDto,
@@ -132,5 +134,27 @@ export class UsersController {
     );
 
     return editedProfile;
+  }
+
+  /**
+   * TODO: DUser 나 Private 유저 온리 걸기.
+   * TODO: user 확인하기.
+   */
+  @Get(':userId/tier')
+  async getUserTier(@Param('userId') userId: string) {
+    return await this.usersService.getUserTier(userId);
+  }
+
+  /**
+   * TODO: DUser 나 Private 유저 온리 걸기.
+   * TODO: user 확인하기.
+   */
+  @Put(':userId/favorite')
+  async editUserFavorite(
+    @Param('userId') userId: string,
+    @Body()
+    editFavoriteDto: EditFavoriteDto,
+  ) {
+    return await this.usersService.editUserFavorite(userId, editFavoriteDto);
   }
 }

--- a/src/domains/users/users.dto.ts
+++ b/src/domains/users/users.dto.ts
@@ -63,3 +63,8 @@ export class EditProfileDto {
   @IsString()
   oneLiner?: string;
 }
+
+export class EditFavoriteDto {
+  // @IsString()
+  sportType: string[];
+}


### PR DESCRIPTION
- editUserFavorite 에는 sportType배열로 받게 하였음

## #️⃣ 관련 이슈 번호
>#32
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
>
getUserTier, editUserFavorite 구현

## 💬리뷰 요구사항(선택)
>
- editUserFavorite 에서 Dto 를 sportType : string[] 으로 만들었습니다.
- 복수개의 favorite sportType 을 받을 수 있음으로
- 추가로 BE 저장소에 제가 오늘 만든 것들 response 다 수정, 검토 해놨습니다.