### PR TITLE
feat: 단위 테스트 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "husky": "^9.0.11",
         "i": "^0.3.7",
         "jest": "^29.5.0",
+        "jest-mock-extended": "^3.0.6",
         "npm": "^10.5.0",
         "prettier": "^3.0.0",
         "source-map-support": "^0.5.21",
@@ -6794,6 +6795,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -9035,6 +9059,19 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock-extended": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.6.tgz",
+      "integrity": "sha512-DJuEoFzio0loqdX8NIwkbE9dgIXNzaj//pefOQxGkoivohpxbSQeNHCAiXkDNA/fmM4EIJDoZnSibP4w3dUJ9g==",
+      "dev": true,
+      "dependencies": {
+        "ts-essentials": "^9.4.2"
+      },
+      "peerDependencies": {
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -14647,6 +14684,20 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.2.tgz",
+      "integrity": "sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "husky": "^9.0.11",
     "i": "^0.3.7",
     "jest": "^29.5.0",
+    "jest-mock-extended": "^3.0.6",
     "npm": "^10.5.0",
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
@@ -83,7 +84,10 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
+    "modulePaths": [
+      "<rootDir>"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/src/domains/matches/matches.service.spec.ts
+++ b/src/domains/matches/matches.service.spec.ts
@@ -1,18 +1,41 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaClient } from '@prisma/client';
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { PrismaService } from 'src/database/prisma/prisma.service';
 import { MatchesService } from './matches.service';
 
 describe('MatchesService', () => {
   let service: MatchesService;
+  let prismaMock: DeepMockProxy<PrismaClient>;
+  let configMock: DeepMockProxy<ConfigService>;
 
   beforeEach(async () => {
+    console.log(__dirname);
+
+    prismaMock = mockDeep<PrismaClient>();
+    configMock = mockDeep<ConfigService>();
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MatchesService],
+      providers: [
+        MatchesService,
+        {
+          provide: PrismaService,
+
+          useValue: prismaMock,
+        },
+        {
+          provide: ConfigService,
+
+          useValue: configMock,
+        },
+      ],
     }).compile();
 
     service = module.get<MatchesService>(MatchesService);
   });
 
-  it('should be defined', () => {
+  test('should be defined', () => {
     expect(service).toBeDefined();
   });
 });

--- a/src/domains/users/users.dto.spec.ts
+++ b/src/domains/users/users.dto.spec.ts
@@ -1,0 +1,26 @@
+import { validate } from 'class-validator';
+import { ErrorCodes } from 'src/common/exceptions/error-codes';
+import { SignUpUserDto } from './users.dto';
+
+test('회원가입 DTO 검증이 성공적으로 수행되어야 함', async () => {
+  const signUpUserDto = new SignUpUserDto();
+  signUpUserDto.email = 'blalbadfas@naver.com';
+  signUpUserDto.password = '!Rh123123312321';
+
+  const validationErrors = await validate(signUpUserDto);
+
+  expect(validationErrors).toHaveLength(0);
+});
+
+test('회원가입 DTO 검증이 INVALID_PASSWORD_FORMAT 에러 메시지를 가진 에러를 반환해야 함', async () => {
+  const signUpUserDto = new SignUpUserDto();
+  signUpUserDto.email = 'blalbadfas@naver.com';
+  signUpUserDto.password = '!h123123312321';
+
+  const result = await validate(signUpUserDto);
+
+  expect(result).toHaveLength(1);
+  expect(result[0].constraints.matches).toBe(
+    ErrorCodes.INVALID_PASSWORD_FORMAT.message,
+  );
+});

--- a/src/domains/users/users.service.spec.ts
+++ b/src/domains/users/users.service.spec.ts
@@ -1,18 +1,37 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { PrismaService } from 'src/database/prisma/prisma.service';
+import { StorageService } from 'src/storage/storage.service';
 import { UsersService } from './users.service';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let prismaServiceMock: DeepMockProxy<PrismaService>;
+  let configServiceMock: DeepMockProxy<ConfigService>;
+  let storageServiceMock: DeepMockProxy<StorageService>;
 
   beforeEach(async () => {
+    prismaServiceMock = mockDeep<PrismaService>();
+    configServiceMock = mockDeep<ConfigService>();
+    storageServiceMock = mockDeep<StorageService>();
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        {
+          provide: PrismaService,
+          useValue: prismaServiceMock,
+        },
+        { provide: ConfigService, useValue: configServiceMock },
+        { provide: StorageService, useValue: storageServiceMock },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
   });
 
-  it('should be defined', () => {
+  test('Service should be defined', () => {
     expect(service).toBeDefined();
   });
 });


### PR DESCRIPTION
## #️⃣ 관련 이슈 번호
>
> #153 

## 📝 작업 내용
>
- 매치 서비스 테스트 의존성 주입(모킹)
- 유저 서비스 테스트 의존성 주입(모킹)
- 유저 dto 테스트 코드 작성(생성)
- jest 모듈 임포트 세팅(typescript 환경에서 절대 경로 설정)
 
## 💬리뷰 요구사항(선택)
